### PR TITLE
Added cookie minimal configuration in auth docs to prevent SessionCookie

### DIFF
--- a/docs/content/4.auth.md
+++ b/docs/content/4.auth.md
@@ -5,6 +5,28 @@ description: Learn how to authenticate users with the strapi module in your Nuxt
 
 > This module exposes composables that are [auto-imported](https://nuxt.com/docs/guide/directory-structure/composables) by Nuxt 3.
 
+## Configuration
+
+When using @nuxtjs/strapi for authentication, the user jwt_token will be stored in a cookie. By using the default cookie configuration, the expiration will be set to "Session", which means the cookie will disappear when the browser is closed, and users will have to log in everytime.
+
+If you want your cookie to stay for longer, we recommand you use the configuration below (expiration is set to 14 days, feel free to change) :
+
+```ts
+// nuxt.config.ts
+
+export default defineNuxtConfig({
+  //...
+  strapi: {
+        cookie: {
+          maxAge: 14 * 24 * 60 * 60,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: true
+        }
+  }
+  //...
+});
+```
+
 ## `useStrapiUser`
 
 Once logged in, you can access your user everywhere:


### PR DESCRIPTION
Using the default cookie config {}, the cookie expiration is set to "Session" which is not what people want went they deploy a website!

Tried to help having a more complete doc on that side

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
